### PR TITLE
ci: resolve the Sonar plugin from the project

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 env:
   SETTINGS_XML: ${{ github.workspace }}/.mvn/settings.xml
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: temurin
 jobs:
   build:

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,8 +1,5 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <activeProfiles>
-        <activeProfile>github</activeProfile>
-    </activeProfiles>
     <profiles>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
 
         <guava.version>33.6.0-jre</guava.version>
         <junit-jupiter-engine.version>5.14.4</junit-jupiter-engine.version>
@@ -191,10 +191,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
             </plugin>
-            <!-- Declared so `mvn sonar:sonar` resolves from the project at a pinned version. Left to
-                 prefix resolution it reached org.codehaus.mojo:sonar-maven-plugin - a relocation stub
-                 for this very artifact, unversioned - which needs a Central metadata lookup and fails
-                 the build with "No plugin found for prefix 'sonar'" whenever that is unavailable. -->
+
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,15 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
             </plugin>
+            <!-- Declared so `mvn sonar:sonar` resolves from the project at a pinned version. Left to
+                 prefix resolution it reached org.codehaus.mojo:sonar-maven-plugin - a relocation stub
+                 for this very artifact, unversioned - which needs a Central metadata lookup and fails
+                 the build with "No plugin found for prefix 'sonar'" whenever that is unavailable. -->
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar-maven-plugin.version}</version>
+            </plugin>
         </plugins>
 
     </build>


### PR DESCRIPTION
### Proposed changes

The build calls `mvn sonar:sonar`, but nothing declared the plugin, so the prefix was resolved against Maven's default plugin groups and landed on org.codehaus.mojo:sonar-maven-plugin - a relocation stub for the same artifact, and unversioned. That needs a Central metadata lookup on every build and fails it outright with "No plugin found for prefix 'sonar'" when the lookup does not happen: every branch build here since 2026-07-24, renovate's among them, died there.

Declaring it pins the version already sitting unused in the properties.

Also drops an activeProfile entry naming a profile that exists in neither the settings nor the pom - `github` is a server id there, not a profile - which warned on every Maven invocation.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
